### PR TITLE
Add site-wide dark mode with sidebar toggle

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -54,7 +54,7 @@
 <style>
   .cursor {
     font-weight: 400;
-    color: #1A6CF0;
+    color: var(--color-accent);
     animation: blink 1s step-end infinite;
     margin-left: 2px;
   }
@@ -74,13 +74,14 @@
     width: 100%;
     max-width: none;
     height: 68vh;
-    background-color: #F8F6F1;
-    border: 1px solid #1A6CF0;
+    background-color: var(--color-bg);
+    border: 1px solid var(--color-accent);
     border-radius: 8px;
     overflow: hidden;
     will-change: transform;
     transform-style: preserve-3d;
     transform: rotateX(0deg) rotateY(0deg) scale3d(1, 1, 1);
+    transition: background-color 0.3s ease, border-color 0.3s ease;
   }
 
   .intro-ticks {
@@ -116,7 +117,7 @@
     left: 2.3%;
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: clamp(10px, 1.1vw, 12px);
-    color: #1C1C1E;
+    color: var(--color-text);
     line-height: 1;
     white-space: nowrap;
   }
@@ -126,7 +127,7 @@
     right: 2.3%;
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: clamp(10px, 1.1vw, 12px);
-    color: #1C1C1E;
+    color: var(--color-text);
     line-height: 1.3;
     text-align: right;
   }
@@ -145,7 +146,7 @@
     left: 2.3%;
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: clamp(10px, 1.1vw, 12px);
-    color: #1C1C1E;
+    color: var(--color-text);
     line-height: 1;
     white-space: nowrap;
   }
@@ -165,11 +166,11 @@
     justify-content: center;
     width: 32px;
     height: 32px;
-    background: #FFFFFF;
+    background: var(--color-bg-secondary);
     border-radius: 9999px;
     text-decoration: none;
     flex-shrink: 0;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease, background-color 0.3s ease;
   }
   .intro-icon-btn:hover { opacity: 0.7; }
   .intro-icon-btn img {
@@ -184,15 +185,15 @@
     justify-content: center;
     height: 32px;
     padding: 0 16px;
-    background: #FFFFFF;
+    background: var(--color-bg-secondary);
     border-radius: 9999px;
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: clamp(10px, 1.1vw, 12px);
-    color: #1C1C1E;
+    color: var(--color-text);
     text-decoration: none;
     white-space: nowrap;
     flex-shrink: 0;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease, background-color 0.3s ease, color 0.3s ease;
   }
   .intro-resume:hover { opacity: 0.7; }
 
@@ -206,6 +207,11 @@
     mix-blend-mode: multiply;
     pointer-events: none;
     z-index: 2;
+  }
+
+  :global(html[data-theme='dark']) .intro-skyline {
+    mix-blend-mode: screen;
+    opacity: 0.6;
   }
 
   /* ── Hero content: matches card width, centred ── */

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -58,6 +58,11 @@ const gepSections = [
       ))}
     </nav>
   )}
+
+  <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
+    <span class="material-icons theme-icon theme-icon--light" aria-hidden="true">light_mode</span>
+    <span class="material-icons theme-icon theme-icon--dark" aria-hidden="true">dark_mode</span>
+  </button>
 </aside>
 
 <script src="../scripts/sidebar.js"></script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,6 +19,14 @@ const { title } = Astro.props;
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@100..900&family=Manrope:wght@200..800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  <script is:inline>
+    (function () {
+      var stored = localStorage.getItem('theme');
+      var theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  </script>
 </head>
 <body>
   <!-- Hamburger: visible on mobile only -->

--- a/src/pages/gep.astro
+++ b/src/pages/gep.astro
@@ -263,7 +263,7 @@ import Layout from '../layouts/Layout.astro';
   .cs-label {
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 10px;
-    color: #999;
+    color: var(--color-text-muted);
     line-height: 1.3;
   }
 
@@ -271,7 +271,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Lexend', system-ui, sans-serif;
     font-size: clamp(36px, 4vw, 56px);
     font-weight: 700;
-    color: #1C1C1E;
+    color: var(--color-text);
     letter-spacing: -0.05em;
     line-height: 1.05;
   }
@@ -280,7 +280,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 16px;
     line-height: 1.7;
-    color: #1C1C1E;
+    color: var(--color-text);
     opacity: 0.65;
     max-width: 600px;
   }
@@ -302,7 +302,7 @@ import Layout from '../layouts/Layout.astro';
     display: block;
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 10px;
-    color: #999;
+    color: var(--color-text-muted);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     margin-bottom: 24px;
@@ -310,14 +310,14 @@ import Layout from '../layouts/Layout.astro';
 
   .cs-divider {
     border: none;
-    border-top: 1px solid rgba(0,0,0,0.08);
+    border-top: 1px solid var(--color-border);
   }
 
   .cs-h2 {
     font-family: 'Lexend', system-ui, sans-serif;
     font-size: 28px;
     font-weight: 700;
-    color: #1C1C1E;
+    color: var(--color-text);
     letter-spacing: -0.03em;
     line-height: 1.2;
     margin-bottom: 16px;
@@ -327,7 +327,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Lexend', system-ui, sans-serif;
     font-size: 16px;
     font-weight: 700;
-    color: #1C1C1E;
+    color: var(--color-text);
     letter-spacing: -0.02em;
     margin-bottom: 8px;
   }
@@ -336,7 +336,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 18px;
     line-height: 1.7;
-    color: #1C1C1E;
+    color: var(--color-text);
     margin-bottom: 32px;
   }
 
@@ -344,7 +344,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 14px;
     line-height: 1.75;
-    color: #1C1C1E;
+    color: var(--color-text);
     opacity: 0.75;
   }
 
@@ -364,7 +364,7 @@ import Layout from '../layouts/Layout.astro';
   .cs-meta-label {
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 10px;
-    color: #999;
+    color: var(--color-text-muted);
     letter-spacing: 0.08em;
     text-transform: uppercase;
   }
@@ -372,7 +372,7 @@ import Layout from '../layouts/Layout.astro';
   .cs-meta-value {
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 14px;
-    color: #1C1C1E;
+    color: var(--color-text);
     line-height: 1.5;
   }
 
@@ -388,13 +388,13 @@ import Layout from '../layouts/Layout.astro';
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 2px;
-    background: rgba(0,0,0,0.06);
+    background: var(--color-divider);
     border-radius: 8px;
     overflow: hidden;
   }
 
   .cs-impact-card {
-    background: #F8F6F1;
+    background: var(--color-bg);
     padding: 32px 28px;
     display: flex;
     flex-direction: column;
@@ -405,7 +405,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Lexend', system-ui, sans-serif;
     font-size: 48px;
     font-weight: 700;
-    color: #1A6CF0;
+    color: var(--color-accent);
     letter-spacing: -0.04em;
     line-height: 1;
   }
@@ -413,7 +413,7 @@ import Layout from '../layouts/Layout.astro';
   .cs-impact-desc {
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 12px;
-    color: #1C1C1E;
+    color: var(--color-text);
     opacity: 0.65;
     line-height: 1.5;
   }
@@ -431,7 +431,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 14px;
     line-height: 1.6;
-    color: #1C1C1E;
+    color: var(--color-text);
     opacity: 0.75;
     padding-left: 20px;
     position: relative;
@@ -444,7 +444,7 @@ import Layout from '../layouts/Layout.astro';
     top: 9px;
     width: 8px;
     height: 2px;
-    background: #1A6CF0;
+    background: var(--color-accent);
     border-radius: 2px;
   }
 
@@ -457,8 +457,8 @@ import Layout from '../layouts/Layout.astro';
   .cs-persona {
     margin-top: 40px;
     padding: 32px;
-    background: rgba(26,108,240,0.04);
-    border-left: 2px solid #1A6CF0;
+    background: var(--color-accent-soft);
+    border-left: 2px solid var(--color-accent);
     border-radius: 0 8px 8px 0;
   }
 
@@ -472,7 +472,7 @@ import Layout from '../layouts/Layout.astro';
   .cs-persona-num {
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 10px;
-    color: #1A6CF0;
+    color: var(--color-accent);
     letter-spacing: 0.08em;
   }
 
@@ -487,11 +487,11 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 13px;
     line-height: 1.65;
-    color: #1C1C1E;
+    color: var(--color-text);
     opacity: 0.7;
     border: none;
     padding: 12px 16px;
-    background: rgba(0,0,0,0.04);
+    background: var(--color-quote-bg);
     border-radius: 4px;
     font-style: italic;
     margin: 0;
@@ -502,7 +502,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Lexend', system-ui, sans-serif;
     font-size: clamp(18px, 2.2vw, 26px);
     font-weight: 700;
-    color: #1C1C1E;
+    color: var(--color-text);
     letter-spacing: -0.03em;
     line-height: 1.3;
     margin-bottom: 40px;
@@ -526,7 +526,7 @@ import Layout from '../layouts/Layout.astro';
   .cs-need-num {
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 10px;
-    color: #1A6CF0;
+    color: var(--color-accent);
     flex-shrink: 0;
     margin-top: 3px;
   }
@@ -535,7 +535,7 @@ import Layout from '../layouts/Layout.astro';
     display: block;
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 13px;
-    color: #1C1C1E;
+    color: var(--color-text);
     margin-bottom: 4px;
   }
 
@@ -557,7 +557,7 @@ import Layout from '../layouts/Layout.astro';
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 14px;
     line-height: 1.6;
-    color: #1C1C1E;
+    color: var(--color-text);
     opacity: 0.75;
   }
 
@@ -565,7 +565,7 @@ import Layout from '../layouts/Layout.astro';
     content: "0" counter(process);
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 10px;
-    color: #1A6CF0;
+    color: var(--color-accent);
     flex-shrink: 0;
     margin-top: 3px;
   }
@@ -587,7 +587,7 @@ import Layout from '../layouts/Layout.astro';
   .cs-learning-num {
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 10px;
-    color: #1A6CF0;
+    color: var(--color-accent);
     flex-shrink: 0;
     margin-top: 3px;
   }
@@ -596,7 +596,7 @@ import Layout from '../layouts/Layout.astro';
     display: block;
     font-family: 'Lexend', system-ui, sans-serif;
     font-size: 15px;
-    color: #1C1C1E;
+    color: var(--color-text);
     margin-bottom: 4px;
     letter-spacing: -0.02em;
   }
@@ -606,7 +606,7 @@ import Layout from '../layouts/Layout.astro';
     padding: 40px 0 0;
     font-family: 'Manrope', system-ui, sans-serif;
     font-size: 11px;
-    color: #1C1C1E;
+    color: var(--color-text);
     opacity: 0.4;
   }
 </style>

--- a/src/scripts/sidebar.js
+++ b/src/scripts/sidebar.js
@@ -1,4 +1,17 @@
 (function () {
+    // ── Dark mode toggle ────────────────────────────────────────────────────
+    const themeToggle = document.getElementById('themeToggle');
+    const themeChangeListeners = [];
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+            const next = isDark ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', next);
+            localStorage.setItem('theme', next);
+            themeChangeListeners.forEach(fn => fn());
+        });
+    }
+
     // ── Mobile sidebar toggle ──────────────────────────────────────────────
     const toggleBtn = document.getElementById('sidebar-toggle');
     const overlay   = document.getElementById('sidebar-overlay');
@@ -66,14 +79,17 @@
     }
 
     function setWidths(targetY) {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const idle   = isDark ? [90, 100, 120]  : [200, 220, 250];
+        const active = isDark ? [92, 151, 255] : [26, 108, 240];
         ticks.forEach((tick, i) => {
             const cy = i * TICK_STEP + 1;
             const g  = gaussian(Math.abs(cy - targetY));
             const w  = MIN_W + (MAX_W - MIN_W) * g;
             tick.style.width = w + 'px';
-            const r  = Math.round(200 + (26  - 200) * g);
-            const gr = Math.round(220 + (108 - 220) * g);
-            const b  = Math.round(250 + (240 - 250) * g);
+            const r  = Math.round(idle[0] + (active[0] - idle[0]) * g);
+            const gr = Math.round(idle[1] + (active[1] - idle[1]) * g);
+            const b  = Math.round(idle[2] + (active[2] - idle[2]) * g);
             tick.style.backgroundColor = `rgb(${r}, ${gr}, ${b})`;
         });
     }
@@ -90,6 +106,7 @@
     let hovering = false;
 
     setWidths(activeTickY);
+    themeChangeListeners.push(() => setWidths(activeTickY));
 
     navLinks.forEach((link, i) => {
         link.addEventListener('mouseenter', () => { activeIdx = i; });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,42 @@
   padding: 0;
 }
 
+:root {
+  --color-bg: #F8F6F1;
+  --color-bg-secondary: #FFFFFF;
+  --color-text: #1C1C1E;
+  --color-text-muted: #999999;
+  --color-accent: #1A6CF0;
+  --color-accent-outline: rgba(26, 108, 240, 0.2);
+  --color-accent-soft: rgba(26, 108, 240, 0.04);
+  --color-tick-idle: rgba(26, 108, 240, 0.2);
+  --color-border: rgba(0, 0, 0, 0.08);
+  --color-divider: rgba(0, 0, 0, 0.06);
+  --color-quote-bg: rgba(0, 0, 0, 0.04);
+  --color-shadow: rgba(26, 108, 240, 0.12);
+  --color-shadow-soft: rgba(26, 108, 240, 0.08);
+  --color-scrim: rgba(0, 0, 0, 0.35);
+  color-scheme: light;
+}
+
+html[data-theme='dark'] {
+  --color-bg: #16171B;
+  --color-bg-secondary: #212227;
+  --color-text: #F1F0EC;
+  --color-text-muted: #8A8A8E;
+  --color-accent: #5C97FF;
+  --color-accent-outline: rgba(92, 151, 255, 0.28);
+  --color-accent-soft: rgba(92, 151, 255, 0.08);
+  --color-tick-idle: rgba(92, 151, 255, 0.22);
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-divider: rgba(255, 255, 255, 0.08);
+  --color-quote-bg: rgba(255, 255, 255, 0.05);
+  --color-shadow: rgba(0, 0, 0, 0.45);
+  --color-shadow-soft: rgba(0, 0, 0, 0.3);
+  --color-scrim: rgba(0, 0, 0, 0.55);
+  color-scheme: dark;
+}
+
 html,
 body {
   -webkit-font-smoothing: antialiased;
@@ -15,7 +51,8 @@ body {
 }
 
 body {
-  background-color: #F8F6F1;
+  background-color: var(--color-bg);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 /* ── Sidebar ── */
@@ -26,12 +63,12 @@ body {
   left: 16px;
   width: 258px;
   height: calc(100vh - 32px);
-  background-color: #F8F6F1;
+  background-color: var(--color-bg);
   overflow: hidden;
   z-index: 10;
   border-radius: 24px;
-  box-shadow: 0 4px 32px rgba(26, 108, 240, 0.12), 0 1px 4px rgba(26, 108, 240, 0.08);
-  transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1);
+  box-shadow: 0 4px 32px var(--color-shadow), 0 1px 4px var(--color-shadow-soft);
+  transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1), background-color 0.3s ease;
 }
 
 body.sidebar-closed .sidebar {
@@ -49,9 +86,9 @@ body.sidebar-closed .sidebar {
 
 .logo-dot {
   position: absolute;
-  background-color: #1A6CF0;
+  background-color: var(--color-accent);
   border-radius: 9999px;
-  outline: 1px solid rgba(26, 108, 240, 0.2);
+  outline: 1px solid var(--color-accent-outline);
   transform-origin: 0% 0%;
   transition: all 0.4s ease-in-out;
 
@@ -94,7 +131,7 @@ body.sidebar-closed .sidebar {
 .tick {
   height: 2px;
   width: 14px;
-  background-color: rgba(26, 108, 240, 0.2);
+  background-color: var(--color-tick-idle);
   border-radius: 9999px;
   transition: width 70ms ease-out, background-color 70ms ease-out;
 }
@@ -105,7 +142,7 @@ body.sidebar-closed .sidebar {
   font-family: 'Manrope', system-ui, sans-serif;
   font-size: 16px;
   line-height: 1;
-  color: #1A6CF0;
+  color: var(--color-accent);
   text-decoration: none;
   white-space: nowrap;
   opacity: 0.4;
@@ -145,7 +182,7 @@ body.sidebar-closed .sidebar {
   font-family: 'Manrope', system-ui, sans-serif;
   font-size: 11px;
   line-height: 1;
-  color: #1A6CF0;
+  color: var(--color-accent);
   text-decoration: none;
   opacity: 0.35;
   padding: 5px 0;
@@ -155,13 +192,56 @@ body.sidebar-closed .sidebar {
 .cs-subnav-link:hover { opacity: 0.8; }
 .cs-subnav-link.active { opacity: 1; font-weight: 700; }
 
+/* ── Theme toggle (bottom of sidebar) ── */
+.theme-toggle {
+  position: absolute;
+  bottom: 32px;
+  left: 36px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent-outline);
+  border-radius: 9999px;
+  cursor: pointer;
+  padding: 0;
+  transition: background-color 0.3s ease, border-color 0.3s ease, opacity 0.2s ease;
+}
+.theme-toggle:hover { opacity: 0.8; }
+
+.theme-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(1);
+  font-size: 20px;
+  color: var(--color-accent);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.theme-icon--dark {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.6);
+}
+
+html[data-theme='dark'] .theme-icon--light {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.6);
+}
+html[data-theme='dark'] .theme-icon--dark {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
 /* ── Main ── */
 
 .main {
   position: relative;
   margin-left: 290px;
-  background-color: #F8F6F1;
-  transition: margin-left 0.4s cubic-bezier(0.25, 1, 0.5, 1);
+  background-color: var(--color-bg);
+  transition: margin-left 0.4s cubic-bezier(0.25, 1, 0.5, 1), background-color 0.3s ease;
 }
 
 .main>* {
@@ -212,7 +292,7 @@ body.sidebar-closed .main {
   font-family: 'Lexend', system-ui, sans-serif;
   font-size: clamp(36px, 4.2vw, 60px);
   font-weight: 700;
-  color: #1C1C1E;
+  color: var(--color-text);
   letter-spacing: -0.05em;
   line-height: 1.05;
 }
@@ -221,7 +301,7 @@ body.sidebar-closed .main {
   font-family: 'Manrope', system-ui, sans-serif;
   font-size: 16px;
   line-height: 1.75;
-  color: #1C1C1E;
+  color: var(--color-text);
   opacity: 0.65;
   margin-bottom: 12px;
   max-width: 520px;
@@ -254,7 +334,7 @@ body.sidebar-closed .main {
   font-family: 'Manrope', system-ui, sans-serif;
   font-size: 10px;
   line-height: 1.3;
-  color: #999999;
+  color: var(--color-text-muted);
 }
 
 .case-study-info {
@@ -267,7 +347,7 @@ body.sidebar-closed .main {
   font-family: system-ui, sans-serif;
   font-size: 24px;
   font-weight: 700;
-  color: #000000;
+  color: var(--color-text);
   line-height: 30px;
 }
 
@@ -275,7 +355,7 @@ body.sidebar-closed .main {
   font-family: 'Manrope', system-ui, sans-serif;
   font-size: 12px;
   line-height: 1.3;
-  color: #1C1C1E;
+  color: var(--color-text);
   opacity: 0.65;
   margin-bottom: 12px;
 }
@@ -287,7 +367,7 @@ body.sidebar-closed .main {
   font-family: 'Manrope', system-ui, sans-serif;
   font-size: 10px;
   line-height: 1.3;
-  color: #1A6CF0;
+  color: var(--color-accent);
 }
 
 .case-study-img {
@@ -308,14 +388,14 @@ body.sidebar-closed .main {
   z-index: 30;
   width: 40px;
   height: 40px;
-  background-color: #1A6CF0;
-  color: #F8F6F1;
+  background-color: var(--color-accent);
+  color: var(--color-bg);
   border: none;
   border-radius: 10px;
   cursor: pointer;
   align-items: center;
   justify-content: center;
-  transition: left 0.4s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.2s ease;
+  transition: left 0.4s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.2s ease, background-color 0.3s ease, color 0.3s ease;
 }
 .sidebar-toggle:hover { opacity: 0.85; }
 
@@ -345,7 +425,7 @@ body:not(.sidebar-closed) .sidebar-toggle .btn-icon--arrow {
 .sidebar-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--color-scrim);
   z-index: 9;
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Adds a CSS custom-property theming system (light/dark) applied across the sidebar, hero, work, and case-study pages
- Adds a dark mode toggle button at the bottom of the sidebar using Material Icons, with a crossfade animation matching the existing mobile menu button
- Theme choice persists via localStorage and is applied before first paint (inline script in `<head>`) to avoid a flash of the wrong theme
- Sidebar's animated tick-mark gradient colors also update to theme-appropriate values on toggle

## Test plan
- [x] Verified toggle switches theme instantly on home and `/gep` case-study pages
- [x] Verified theme persists across page reload
- [x] Verified no console/page errors via headless browser check

🤖 Generated with [Claude Code](https://claude.com/claude-code)